### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.chess.json
+++ b/org.gnome.chess.json
@@ -17,9 +17,6 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options": {
-        "cflags": "-O2 -g"
-    },
     "cleanup": ["/share/gnuchess", "/share/info", "/share/man", "/include"],
     "modules": [
         {


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.