### PR TITLE
Add stockfish support

### DIFF
--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -13,36 +13,36 @@
     ],
     "cleanup": ["/share/gnuchess", "/share/info", "/share/man", "/include"],
     "modules": [
-    	{
+        {
             "name": "stockfish",
             "buildsystem": "simple",
             "build-options" : {
-				"arch": {
-				    "x86_64": {
-				        "env": {
-				        	"ARCH": "x86-64"
-				        }
-				    },
-				    "i386": {
-					    "env": {
-				        	"ARCH": "x86-32"
-				        }
-				    },
-				    "arm": {
-					    "env": {
-				        	"ARCH": "armv7"
-				        }
-				    },
-				    "aarch64": {
-					    "env": {
-				        	"ARCH": "armv7"
-				        }
-				    }
-				}
-			},
+                "arch": {
+                    "x86_64": {
+                        "env": {
+                            "ARCH": "x86-64"
+                        }
+                    },
+                    "i386": {
+                        "env": {
+                            "ARCH": "x86-32"
+                        }
+                    },
+                    "arm": {
+                        "env": {
+                            "ARCH": "armv7"
+                        }
+                    },
+                    "aarch64": {
+                        "env": {
+                            "ARCH": "armv7"
+                        }
+                    }
+                }
+            },
             "build-commands": [
-            	"make build",
-            	"install -D stockfish /app/bin/stockfish"
+                "make build",
+                "install -D stockfish /app/bin/stockfish"
             ],
             "sources": [
                 {

--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -14,6 +14,23 @@
     "cleanup": ["/share/gnuchess", "/share/info", "/share/man", "/include"],
     "modules": [
         {
+            "name": "phalanx",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "install -D phalanx /app/bin/phalanx",
+                "install -D pbook.phalanx /app/lib/pbook.phalanx",
+                "install -D sbook.phalanx /app/lib/sbook.phalanx"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/phalanx/Version%20XXV/phalanx-XXV-source.tgz",
+                    "sha256": "b3874d5dcd22c64626b2c955b18b27bcba3aa727855361a91eab57a6324b22dd"
+                }
+            ]
+        },
+        {
             "name": "stockfish",
             "buildsystem": "simple",
             "build-options" : {

--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -13,6 +13,45 @@
     ],
     "cleanup": ["/share/gnuchess", "/share/info", "/share/man", "/include"],
     "modules": [
+    	{
+            "name": "stockfish",
+            "buildsystem": "simple",
+            "build-options" : {
+				"arch": {
+				    "x86_64": {
+				        "env": {
+				        	"ARCH": "x86-64"
+				        }
+				    },
+				    "i386": {
+					    "env": {
+				        	"ARCH": "x86-32"
+				        }
+				    },
+				    "arm": {
+					    "env": {
+				        	"ARCH": "armv7"
+				        }
+				    },
+				    "aarch64": {
+					    "env": {
+				        	"ARCH": "armv7"
+				        }
+				    }
+				}
+			},
+            "build-commands": [
+            	"make build",
+            	"install -D stockfish /app/bin/stockfish"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://stockfishchess.org/files/stockfish-10-src.zip",
+                    "sha256": "29bd01e7407098aa9e851b82f6ea4bf2b46d26e9075a48a269cb1e40c582a073"
+                }
+            ]
+        },
         {
             "name": "gnuchess",
             "sources": [


### PR DESCRIPTION
I have only test the x86_64 build. Unfortunately stockfish has only a weird makefile which needs the `ARCH` variable to be specified accordingly to the architecture. I don't see in the makefile any support for aarch64 but maybe the armv7 build can work as well, or maybe we can override the other variables of the makefile to get a aarch64 build. Is there any way I can test it in aarch64 (I haven't found any flatpak guide for compiling and testing in different architecture apart i386).