### PR TITLE
fix phalanx books

### DIFF
--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -19,14 +19,19 @@
             "build-commands": [
                 "make",
                 "install -D phalanx /app/bin/phalanx",
-                "install -D pbook.phalanx /app/lib/pbook.phalanx",
-                "install -D sbook.phalanx /app/lib/sbook.phalanx"
+                "install -D pbook.phalanx /app/share/phalanx/pbook.phalanx",
+                "install -D sbook.phalanx /app/share/phalanx/sbook.phalanx",
+                "install -D eco.phalanx /app/share/phalanx/eco.phalanx"
             ],
             "sources": [
                 {
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/project/phalanx/Version%20XXV/phalanx-XXV-source.tgz",
                     "sha256": "b3874d5dcd22c64626b2c955b18b27bcba3aa727855361a91eab57a6324b22dd"
+                },
+                {
+                    "type": "patch",
+                    "path": "phalanx-books-path.patch"
                 }
             ]
         },

--- a/phalanx-books-path.patch
+++ b/phalanx-books-path.patch
@@ -1,0 +1,60 @@
+--- ./phalanx-old.h	2016-05-01 21:06:21.000000000 +0300
++++ ./phalanx.h	2019-10-10 19:37:53.697318140 +0300
+@@ -195,7 +195,7 @@
+ #define PBOOK_FILE "pbook.phalanx"
+ #endif
+ #ifndef PBOOK_DIR
+-#define PBOOK_DIR "/usr/local/lib/phalanx"
++#define PBOOK_DIR "/app/share/phalanx"
+ #endif
+ 
+ /* secondary (binary, large, generated from pgn) book */
+@@ -203,14 +203,14 @@
+ #define SBOOK_FILE "sbook.phalanx"
+ #endif
+ #ifndef SBOOK_DIR
+-#define SBOOK_DIR "/usr/local/lib/phalanx"
++#define SBOOK_DIR "/app/share/phalanx"
+ #endif
+ 
+ #ifndef ECO_FILE
+ #define ECO_FILE "eco.phalanx"
+ #endif
+ #ifndef ECO_DIR
+-#define ECO_DIR "/usr/local/lib/phalanx"
++#define ECO_DIR "/app/share/phalanx"
+ #endif
+ 
+ #ifndef LEARN_FILE
+ 
+
+--- phalanx-XXIII.orig/phalanx.c
++++ phalanx-XXIII/phalanx.c
+@@ -325,8 +325,17 @@ EcoDir = get_book_file(EcoDir,ENV_ECO,EC
+ Eco = fopen(EcoDir,"rb");
+ if( Flag.learn )
+ {
++	char learn_dir[128];
++	struct stat st;
++
++	sprintf(learn_dir, "%s/.phalanx", getenv("XDG_DATA_HOME"));
++
++	if(stat(learn_dir, &st) || !S_ISDIR(st.st_mode)) {
++		mkdir(learn_dir, 0755);
++	}
++	
+ 	LbookDir
+-	= get_book_file(LbookDir,ENV_LEARN,LEARN_DIR,LEARN_FILE,R_OK|W_OK);
++	= get_book_file(LbookDir,ENV_LEARN,learn_dir,LEARN_FILE,R_OK|W_OK);
+ 	Learn.f = fopen(LbookDir,"r+");
+ 	if( Learn.f == NULL )
+ 	{
+@@ -334,7 +343,7 @@ if( Flag.learn )
+ 		int b[LFSZ];
+ 		char filename[256];
+ 		memset( b, 0, LFSZ*sizeof(int) );
+-  		sprintf(filename,"./%s",LEARN_FILE);
++  		sprintf(filename,"%s/%s", learn_dir, LEARN_FILE);
+ 		free( LbookDir );
+ 		LbookDir = strdup( filename );
+ 		Learn.f = fopen(LbookDir,"w+");


### PR DESCRIPTION
@mcatanzaro @Zlopez ok this fixes the books path.
I patched the paths beacause passing them through make command didn't work for me. I used the patch from OpenSuse for the learn book with difference I set it to use XDG_DATA_HOME instead of HOME which the app didn't have access (and shouldn't have)

```
[📦 org.gnome.Chess ~]$ phalanx -l+
Phalanx XXV
primary book /app/share/phalanx/pbook.phalanx, 48618 bytes
secondary book /app/share/phalanx/sbook.phalanx, 263970 bytes
learning file /home/thanos/.var/app/org.gnome.Chess/data/.phalanx/learn.phalanx, 262144 bytes
eco file /app/share/phalanx/eco.phalanx, 171176 bytes
tellics set 1 Phalanx XXV, 820 kB hashtable, 47/257 kB P/S opening book
```

If you test it, tell me if you experience any error "the engine is confused" when phalanx is used with gnome-chess at "Hard" difficulty. I experienced a couple of those both with the flatpak and the native packages of Ubuntu 19.10 which is beta so I don't know.