### PR TITLE
Update gnuchess

### DIFF
--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -74,8 +74,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftpmirror.gnu.org/chess/gnuchess-6.2.5.tar.gz",
-                    "sha256": "9a99e963355706cab32099d140b698eda9de164ebce40a5420b1b9772dd04802"
+                    "url": "https://ftpmirror.gnu.org/chess/gnuchess-6.2.9.tar.gz",
+                    "sha256": "ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890"
                 }
             ]
         },


### PR DESCRIPTION
I originally tried to update stockfish as well, but any newer version than 11 did not compile.